### PR TITLE
Rename GeanyLatex and remove Sendmail from exclude list

### DIFF
--- a/content/geanylatex.html
+++ b/content/geanylatex.html
@@ -1,6 +1,4 @@
 <h2>GeanyLaTeX</h2>
 <p>
-  The documentation for the GeanyLaTeX plugin can be found at
-  <a class="reference external" href=
-  "http://frank.uvena.de/en/Geany/geanylatex">http://frank.uvena.de/en/Geany/geanylatex</a>.
+  The plugin has been renamed an can now be found <a href="http://plugins.geany.org/latex.html">here</a>.
 </p>

--- a/content/latex.html
+++ b/content/latex.html
@@ -1,0 +1,6 @@
+<h2>GeanyLaTeX</h2>
+<p>
+  The documentation for the GeanyLaTeX plugin can be found at
+  <a class="reference external" href=
+  "https://plugins.geany.org/latex/">https://plugins.geany.org/latex/</a>.
+</p>

--- a/gencontent.sh
+++ b/gencontent.sh
@@ -68,7 +68,7 @@ LOGDIR=${WORKDIR}"gencontent_logs/"
 
 # plugins to exclude from the nightly re-generation via rst2html because they
 # have a separate HTML page not generated from the README file
-declare -a EXCLUDE_PLUGINS=( geanylatex geanylua jsonprettifier quick_open_file sendmail togglebar pynav )
+declare -a EXCLUDE_PLUGINS=( latex geanylua jsonprettifier quick_open_file togglebar pynav )
 
 RST2HTML=$(which rst2html)
 TIDY=$(which tidy)


### PR DESCRIPTION
We don't have a replacement HTML file for Sendmail, so use the upstream
README.
Fix broken link to upstream LaTeX documentation.