### PR TITLE
use rst2html5 instead of rst2html

### DIFF
--- a/content/README
+++ b/content/README
@@ -39,14 +39,14 @@ wait a night before contacting Dominic to have a deeper look on the issue.
 -------
 
 This one will only work, if you write your README file in restructuredText
-as some other plugin authors do. You will need to use two tools: rst2html
+as some other plugin authors do. You will need to use two tools: rst2html5
 and HTML Tidy. Dominic wrote some configuration files for use with those
 tools. The files can be found on github at https://github.com/geany/plugins.geany.org/tree/master/content.
 The result should be an almost perfect HTML file which can be
 included into the plugins.geany.org website. Do this steps to generate the
 file:
 
-    rst2html --config=rst2html_config.conf README > {your plugin name}.html
+    rst2html5 --config=rst2html_config.conf README > {your plugin name}.html
     tidy -config tidy.conf {your plugin name}.html
 
 

--- a/content/README.html
+++ b/content/README.html
@@ -37,14 +37,14 @@ your file. He will do the rest for you.</li>
 <div class="section" id="nd-way">
 <h3>2nd Way</h3>
 <p>This one will only work, if you write your README file in restructuredText
-as some other plugin authors do. You will need to use two tools: rst2html
+as some other plugin authors do. You will need to use two tools: rst2html5
 and HTML Tidy. Dominic wrote some configuration files for use with those
 tools. If you do not have them yet, feel free to contact Dominic to get
 them. The result should be an almost perfect HTML file which can be
 included into the plugins.geany.org website. Do this steps to generate the
 file:</p>
 <blockquote>
-rst2html --config=rst2html_config.conf README &gt; {your plugin name}.html
+rst2html5 --config=rst2html_config.conf README &gt; {your plugin name}.html
 tidy -config tidy.conf {your plugin name}.html</blockquote>
 <p>While {your plugin name} is the actual UNIX name (lowercase!) of your plugin.
 Note: There is no need for HTML headers and body and so on. Those will be

--- a/gencontent.sh
+++ b/gencontent.sh
@@ -66,11 +66,11 @@ CONTENTDIR=${WORKDIR}"content/"
 # generation of the content files
 LOGDIR=${WORKDIR}"gencontent_logs/"
 
-# plugins to exclude from the nightly re-generation via rst2html because they
+# plugins to exclude from the nightly re-generation via rst2html5 because they
 # have a separate HTML page not generated from the README file
 declare -a EXCLUDE_PLUGINS=( geanylua jsonprettifier quick_open_file togglebar pynav )
 
-RST2HTML=$(which rst2html)
+RST2HTML5=$(which rst2html5)
 TIDY=$(which tidy)
 
 # List of plugins, available in the letest release
@@ -80,9 +80,9 @@ declare -a RELEASE_PLUGIN_LIST
 declare -a MASTER_PLUGIN_LIST
 
 
-if [ ! -x "$RST2HTML" ]
+if [ ! -x "$RST2HTML5" ]
 then
-    echo "rst2html not found. Exiting."
+    echo "rst2html5 not found; to install it, use 'pip install rst2html5'. Exiting."
     exit 127
 fi
 
@@ -193,7 +193,7 @@ function gen_html_from_readme()
 
     cd ${CONTENTDIR}
     # TODO: newer versions of rst2html may face problems with the configuration files encoding
-    $RST2HTML -s --config=${CONTENTDIR}"rst2html_config.conf" ${SOURCESDIR}${plugin}/README ${SOURCESDIR}.README.html 2> $LOGFILE
+    $RST2HTML5 -s --config=${CONTENTDIR}"rst2html_config.conf" ${SOURCESDIR}${plugin}/README ${SOURCESDIR}.README.html 2> $LOGFILE
     cd - > /dev/null
 
     retcode=$?


### PR DESCRIPTION
I'm not sure if this is a desired change or not, but when I tried
installing rst2html on Debian 9 with 'pip install', it failed. I got
rst2html5 installed with no problem though.